### PR TITLE
Add session controller request specs

### DIFF
--- a/app/controllers/concerns/session_manageable.rb
+++ b/app/controllers/concerns/session_manageable.rb
@@ -5,8 +5,8 @@ module SessionManageable
   extend ActiveSupport::Concern
 
   included do
-    skip_before_action :require_user!, only: %i[new create], if: -> { defined?(Users::BaseController) && is_a?(Users::BaseController) }
-    skip_before_action :require_admin!, only: %i[new create], if: -> { defined?(Admins::BaseController) && is_a?(Admins::BaseController) }
+    skip_before_action :require_user!, only: %i[new create] if defined?(Users::BaseController) && self < Users::BaseController
+    skip_before_action :require_admin!, only: %i[new create] if defined?(Admins::BaseController) && self < Admins::BaseController
   end
 
   def new; end

--- a/app/models/user/email_change.rb
+++ b/app/models/user/email_change.rb
@@ -15,11 +15,11 @@ class User::EmailChange < ApplicationRecord
   alias change_token token
 
   def change_digest
-    digest
+    self[:change_digest]
   end
 
   def change_digest=(value)
-    self.digest = value
+    self[:change_digest] = value
   end
 
   def send_email_changed_email

--- a/app/models/user/password_reset.rb
+++ b/app/models/user/password_reset.rb
@@ -14,11 +14,11 @@ class User::PasswordReset < ApplicationRecord
   alias reset_token token
 
   def reset_digest
-    digest
+    self[:reset_digest]
   end
 
   def reset_digest=(value)
-    self.digest = value
+    self[:reset_digest] = value
   end
 
   def send_password_reset_email

--- a/spec/requests/admins/sessions_spec.rb
+++ b/spec/requests/admins/sessions_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Admins::Sessions', type: :request do
+  describe 'POST /admins/session' do
+    let!(:admin) { create(:admin, password: 'password') }
+
+    context 'with valid credentials' do
+      it 'signs in admin' do
+        post admins_session_path, params: { email: admin.email, password: 'password' }
+        expect(session[:admin_id]).to eq(admin.id)
+        expect(response).to redirect_to(admins_users_path)
+      end
+    end
+
+    context 'with invalid credentials' do
+      it 'renders new' do
+        allow_any_instance_of(ActionView::Base).to receive(:stylesheet_link_tag).and_return('')
+        post admins_session_path, params: { email: admin.email, password: 'wrong' }
+        expect(session[:admin_id]).to be_nil
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /admins/session' do
+    let!(:admin) { create(:admin, password: 'password') }
+
+    before do
+      post admins_session_path, params: { email: admin.email, password: 'password' }
+    end
+
+    it 'signs out admin' do
+      delete admins_session_path
+      expect(session[:admin_id]).to be_nil
+      expect(response).to redirect_to(new_admins_session_path)
+    end
+  end
+end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Users::Sessions', type: :request do
+  describe 'POST /users/session' do
+    let!(:user) { create(:user_core, password: 'password') }
+
+    context 'with valid credentials' do
+      it 'signs in user' do
+        post users_session_path, params: { email: user.email, password: 'password' }
+        expect(session[:user_id]).to eq(user.id)
+        expect(response).to redirect_to(mypage_users_path)
+      end
+    end
+
+    context 'with invalid credentials' do
+      it 'renders new' do
+        allow_any_instance_of(ActionView::Base).to receive(:stylesheet_link_tag).and_return('')
+        post users_session_path, params: { email: user.email, password: 'wrong' }
+        expect(session[:user_id]).to be_nil
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /users/session' do
+    let!(:user) { create(:user_core, password: 'password') }
+
+    before do
+      post users_session_path, params: { email: user.email, password: 'password' }
+    end
+
+    it 'signs out user' do
+      delete users_session_path
+      expect(session[:user_id]).to be_nil
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add request specs for user and admin sessions
- fix Tokenizable digest accessor methods
- skip authentication callbacks properly in SessionManageable

## Testing
- `bin/rubocop`
- `bin/rspec`