### PR TITLE
開発環境構築のための修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Myapp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
     config.active_job.queue_adapter = :solid_queue
+    config.solid_queue.connects_to = { database: { writing: :queue, reading: :queue } }
     config.mission_control.jobs.base_controller_class = "Admins::BaseController"
 
     config.time_zone = "Tokyo"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,6 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # config.active_job.queue_name_prefix = "myapp_production"
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -60,7 +60,6 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # config.active_job.queue_name_prefix = "myapp_production"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres
+    image: postgres:16
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
- README通りにpostgresのバージョンを16に固定
  - latestだとver18になり、ver18以降は開発環境でのマウントするvolumeの書き方が変わるため
- 全ての環境でsolid_queueがqueDBを見るように修正