### PR TITLE
brakemanのensure-latestの引数を復活

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mswin mingw x64_mingw ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", "~> 7.1.0", require: false
+  gem "brakeman", "~> 8.0", require: false
   gem "rubocop"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.2)
+    brakeman (8.0.2)
       racc
     builder (3.3.0)
     bullet (8.0.8)
@@ -434,7 +434,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.20)
   bootsnap
-  brakeman (~> 7.1.0)
+  brakeman (~> 8.0)
   bullet
   capybara
   cgi (= 0.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.0)
+    brakeman (7.1.2)
       racc
     builder (3.3.0)
     bullet (8.0.8)

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,4 +2,6 @@
 require "rubygems"
 require "bundler/setup"
 
+ARGV.unshift("--ensure-latest")
+
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
- https://github.com/irori-dev/app-base/pull/55 でbrakemanの最新確認をする引数を消してしまっていた
- brakemanを最新バージョンである8.0.2に引き上げ、"--ensure-latest"の引数も復活させた